### PR TITLE
Add tuck arms client code back to tuck_arms_main.py

### DIFF
--- a/pr2_tuck_arms_action/scripts/tuck_arms.py
+++ b/pr2_tuck_arms_action/scripts/tuck_arms.py
@@ -32,7 +32,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # Author: Wim Meeussen
-
 """
 usage: tuck_arms.py [-l ACTION] [-r ACTION] [-q]
 Options:
@@ -51,55 +50,59 @@ import getopt
 import rospy
 
 
-def usage():           
-    print __doc__ % vars()               
+def usage():
+    print __doc__ % vars()
     rospy.signal_shutdown("Help requested")
 
 
 def main():
     action_name = 'tuck_arms'
     quit_when_finished = False
-  
-    # check for command line arguments, and send goal to action server if required
+
+    # check for command line arguments, and send goal to action server if
+    # required
     myargs = rospy.myargv()[1:]
     if len(myargs):
         goal = TuckArmsGoal()
         goal.tuck_left = True
         goal.tuck_right = True
-        opts, args = getopt.getopt(myargs, 'hql:r:', ['quit','left','right'])
+        opts, args = getopt.getopt(myargs, 'hql:r:', ['quit', 'left', 'right'])
         for arm, action in opts:
             if arm in ('-l', '--left'):
                 if action in ('tuck', 't'):
-                  goal.tuck_left = True
+                    goal.tuck_left = True
                 elif action in ('untuck', 'u'):
-                  goal.tuck_left = False
+                    goal.tuck_left = False
                 else:
-                   rospy.logerr('Invalid action for right arm: %s'%action)
-                   rospy.signal_shutdown("ERROR")
-  
+                    rospy.logerr('Invalid action for right arm: %s' % action)
+                    rospy.signal_shutdown("ERROR")
+
             if arm in ('-r', '--right'):
                 if action in ('tuck', 't'):
                     goal.tuck_right = True
                 elif action in ('untuck', 'u'):
                     goal.tuck_right = False
                 else:
-                    rospy.logerr('Invalid action for left arm: %s'%action)
+                    rospy.logerr('Invalid action for left arm: %s' % action)
                     rospy.signal_shutdown("ERROR")
-  
+
             if arm in ('--quit', '-q'):
                 quit_when_finished = True
-  
+
             if arm in ('--help', '-h'):
                 usage()
-        
-        tuck_arm_client = actionlib.SimpleActionClient(action_name, TuckArmsAction)
+
+        tuck_arm_client = actionlib.SimpleActionClient(action_name,
+                                                       TuckArmsAction)
         rospy.logdebug('Waiting for action server to start')
         tuck_arm_client.wait_for_server(rospy.Duration())
         rospy.logdebug('Sending goal to action server')
-        tuck_arm_client.send_goal_and_wait(goal, rospy.Duration(30.0), rospy.Duration(5.0))
-  
+        tuck_arm_client.send_goal_and_wait(goal, rospy.Duration(30.0),
+                                           rospy.Duration(5.0))
+
         if quit_when_finished:
             rospy.signal_shutdown("Quitting")
+
 
 if __name__ == '__main__':
     rospy.init_node('tuck_arms_client')

--- a/pr2_tuck_arms_action/scripts/tuck_arms.py
+++ b/pr2_tuck_arms_action/scripts/tuck_arms.py
@@ -33,5 +33,75 @@
 #
 # Author: Wim Meeussen
 
-from pr2_tuck_arms_action import tuck_arms_main
-tuck_arms_main.main()
+"""
+usage: tuck_arms.py [-l ACTION] [-r ACTION] [-q]
+Options:
+  -l or --left   Action for left arm
+  -r or --right  Action for right arm
+  -q or --quit   Shut down the action client after completing action
+Actions:
+  t or tuck
+  u or untuck
+
+"""
+
+from pr2_common_action_msgs.msg import TuckArmsAction, TuckArmsGoal
+import actionlib
+import getopt
+import rospy
+
+
+def usage():           
+    print __doc__ % vars()               
+    rospy.signal_shutdown("Help requested")
+
+
+def main():
+    action_name = 'tuck_arms'
+    quit_when_finished = False
+  
+    # check for command line arguments, and send goal to action server if required
+    myargs = rospy.myargv()[1:]
+    if len(myargs):
+        goal = TuckArmsGoal()
+        goal.tuck_left = True
+        goal.tuck_right = True
+        opts, args = getopt.getopt(myargs, 'hql:r:', ['quit','left','right'])
+        for arm, action in opts:
+            if arm in ('-l', '--left'):
+                if action in ('tuck', 't'):
+                  goal.tuck_left = True
+                elif action in ('untuck', 'u'):
+                  goal.tuck_left = False
+                else:
+                   rospy.logerr('Invalid action for right arm: %s'%action)
+                   rospy.signal_shutdown("ERROR")
+  
+            if arm in ('-r', '--right'):
+                if action in ('tuck', 't'):
+                    goal.tuck_right = True
+                elif action in ('untuck', 'u'):
+                    goal.tuck_right = False
+                else:
+                    rospy.logerr('Invalid action for left arm: %s'%action)
+                    rospy.signal_shutdown("ERROR")
+  
+            if arm in ('--quit', '-q'):
+                quit_when_finished = True
+  
+            if arm in ('--help', '-h'):
+                usage()
+        
+        tuck_arm_client = actionlib.SimpleActionClient(action_name, TuckArmsAction)
+        rospy.logdebug('Waiting for action server to start')
+        tuck_arm_client.wait_for_server(rospy.Duration())
+        rospy.logdebug('Sending goal to action server')
+        tuck_arm_client.send_goal_and_wait(goal, rospy.Duration(30.0), rospy.Duration(5.0))
+  
+        if quit_when_finished:
+            rospy.signal_shutdown("Quitting")
+
+if __name__ == '__main__':
+    rospy.init_node('tuck_arms_client')
+    main()
+    rospy.spin()

--- a/pr2_tuck_arms_action/src/pr2_tuck_arms_action/tuck_arms_main.py
+++ b/pr2_tuck_arms_action/src/pr2_tuck_arms_action/tuck_arms_main.py
@@ -34,20 +34,6 @@
 # Author: Wim Meeussen
 # Modified by Jonathan Bohren to be an action and for untucking
 
-
-"""
-usage: tuck_arms.py [-l ACTION] [-r ACTION]
-Options:
-  -l or --left   Action for left arm
-  -r or --right  Action for right arm
-Actions:
-  t or tuck
-  u or untuck
-
-NB: If two arms are specified, actions must be the same for both arms.
-
-"""
-
 import signal
 
 import rospy
@@ -63,10 +49,6 @@ from pr2_controllers_msgs.msg import *
 from pr2_common_action_msgs.msg import *
 import getopt
 import actionlib
-
-def usage():           
-  print __doc__ % vars()               
-  rospy.signal_shutdown("Help requested")
 
 # Joint names
 joint_names = ["shoulder_pan", 
@@ -129,6 +111,7 @@ class TuckArmsActionServer:
 	    rospy.logerr("pr2_tuck_arms: right_joint_client action server did not come up within timelimit")
 
     # Construct action server
+    rospy.loginfo("Constructing action server")
     self.action_server = actionlib.simple_action_server.SimpleActionServer(node_name,TuckArmsAction, self.executeCB)
 
 
@@ -273,49 +256,6 @@ def main():
   rospy.init_node(action_name)
   rospy.sleep(0.001)  # wait for time
   tuck_arms_action_server = TuckArmsActionServer(action_name)
-
-  quit_when_finished = False
-
-  # check for command line arguments, and send goal to action server if required
-  myargs = rospy.myargv()[1:]
-  if len(myargs):
-    goal = TuckArmsGoal()
-    goal.tuck_left = True
-    goal.tuck_right = True
-    opts, args = getopt.getopt(myargs, 'hql:r:', ['quit','left','right'])
-    for arm, action in opts:
-      if arm in ('-l', '--left'):
-        if action in ('tuck', 't'):
-          goal.tuck_left = True
-        elif action in ('untuck', 'u'):
-          goal.tuck_left = False
-        else:
-           rospy.logerr('Invalid action for right arm: %s'%action)
-           rospy.signal_shutdown("ERROR")
-
-      if arm in ('-r', '--right'):
-        if action in ('tuck', 't'):
-          goal.tuck_right = True
-        elif action in ('untuck', 'u'):
-          goal.tuck_right = False
-        else:
-           rospy.logerr('Invalid action for left arm: %s'%action)
-           rospy.signal_shutdown("ERROR")
-
-      if arm in ('--quit', '-q'):
-        quit_when_finished = True
-
-      if arm in ('--help', '-h'):
-        usage()
-    
-    tuck_arm_client = actionlib.SimpleActionClient(action_name, TuckArmsAction)
-    rospy.logdebug('Waiting for action server to start')
-    tuck_arm_client.wait_for_server(rospy.Duration(10.0))
-    rospy.logdebug('Sending goal to action server')
-    tuck_arm_client.send_goal_and_wait(goal, rospy.Duration(30.0), rospy.Duration(5.0))
-
-    if quit_when_finished:
-      rospy.signal_shutdown("Quitting")
 
   rospy.spin()
 


### PR DESCRIPTION
Could we add the action client code for tucking the arms back into tuck_arms_main? This is more convenient because right now, running `rosrun pr2_tuck_arms_action tuck_arms.py -lt -rt` just starts the action server, without doing anything, and there's no other way to easily tuck the arms without writing our own action client code.
