### PR TITLE
add depend to pr2_controller_msgs

### DIFF
--- a/joint_trajectory_generator/CMakeLists.txt
+++ b/joint_trajectory_generator/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   urdf 
   angles
   actionlib
+  pr2_controllers_msgs
   joint_trajectory_action)
 
 find_package(Boost REQUIRED COMPONENTS thread)
@@ -14,7 +15,7 @@ find_package(orocos_kdl REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES joint_trajectory_generation
-  CATKIN_DEPENDS roscpp urdf angles actionlib joint_trajectory_action
+  CATKIN_DEPENDS roscpp urdf angles actionlib joint_trajectory_action pr2_controllers_msgs
   DEPENDS Boost orocos_kdl)
 
 include_directories(

--- a/joint_trajectory_generator/package.xml
+++ b/joint_trajectory_generator/package.xml
@@ -24,6 +24,7 @@
   <build_depend>angles</build_depend>
   <build_depend>orocos_kdl</build_depend>
   <build_depend>joint_trajectory_action</build_depend>
+  <build_depend>pr2_controllers_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>urdf</build_depend>
 
@@ -31,6 +32,7 @@
   <run_depend>angles</run_depend>
   <run_depend>orocos_kdl</run_depend>
   <run_depend>joint_trajectory_action</run_depend>
+  <run_depend>pr2_controllers_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>urdf</run_depend>
 


### PR DESCRIPTION
```
______________________________________
Errors     << joint_trajectory_generator:check /home/k-okada/catkin_ws/ws_pr2/logs/joint_trajectory_generator/build.check.000.log             
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by
  "pr2_contollers_msgs" with any of the following names:

    pr2_contollers_msgsConfig.cmake
    pr2_contollers_msgs-config.cmake

  Add the installation prefix of "pr2_contollers_msgs" to CMAKE_PREFIX_PATH
  or set "pr2_contollers_msgs_DIR" to a directory containing one of the above
  files.  If "pr2_contollers_msgs" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by
  "pr2_contollers_msgs" with any of the following names:

    pr2_contollers_msgsConfig.cmake
    pr2_contollers_msgs-config.cmake

  Add the installation prefix of "pr2_contollers_msgs" to CMAKE_PREFIX_PATH
  or set "pr2_contollers_msgs_DIR" to a directory containing one of the above
  files.  If "pr2_contollers_msgs" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)

```