### PR TITLE
pr2_tilt_laser_interface: remove unused Boost signals dependency

### DIFF
--- a/pr2_tilt_laser_interface/CMakeLists.txt
+++ b/pr2_tilt_laser_interface/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_conversions
   laser_geometry)
 
-find_package(Boost REQUIRED COMPONENTS signals)
+find_package(Boost REQUIRED)
 
 add_action_files(DIRECTORY action FILES GetSnapshot.action)
 generate_messages(DEPENDENCIES actionlib_msgs sensor_msgs pr2_msgs)


### PR DESCRIPTION
The `pr2_tilt_laser_interface` package tries to find the Boost signals library. This library is not used by the package and has been deprecated since Boost 1.54 and was removed in Boost 1.69. This causes this package to fail to build with the latest version of Boost.