### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/joint_trajectory_action_tools/package.xml
+++ b/joint_trajectory_action_tools/package.xml
@@ -16,6 +16,8 @@
   <url type="repository">https://github.com/PR2/pr2_common_actions</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>roslib</build_depend>
   <build_depend>rospy</build_depend>

--- a/joint_trajectory_action_tools/package.xml
+++ b/joint_trajectory_action_tools/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>joint_trajectory_action_tools</name>
   <version>0.0.12</version>
   <description>
@@ -23,10 +23,10 @@
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>pr2_controllers_msgs</build_depend>
 
-  <run_depend>roslib</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>joint_trajectory_action</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>pr2_controllers_msgs</run_depend>
+  <exec_depend>roslib</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>joint_trajectory_action</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>pr2_controllers_msgs</exec_depend>
 
 </package>

--- a/pr2_tuck_arms_action/package.xml
+++ b/pr2_tuck_arms_action/package.xml
@@ -11,6 +11,8 @@
   <author>Wim Meeussen</author> 
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>

--- a/pr2_tuck_arms_action/package.xml
+++ b/pr2_tuck_arms_action/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>pr2_tuck_arms_action</name>
   <version>0.0.12</version>
   <description>The pr2_tuck_arms_action package</description>
@@ -19,12 +19,12 @@
   <build_depend>rospy</build_depend>
   <build_depend>trajectory_msgs</build_depend>
 
-  <run_depend>actionlib</run_depend>
-  <run_depend>actionlib_msgs</run_depend>
-  <run_depend>pr2_common_action_msgs</run_depend>
-  <run_depend>pr2_controllers_msgs</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
+  <exec_depend>actionlib</exec_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
+  <exec_depend>pr2_common_action_msgs</exec_depend>
+  <exec_depend>pr2_controllers_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
 
 
   <export>


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.